### PR TITLE
Relax dependencies

### DIFF
--- a/tabulo.gemspec
+++ b/tabulo.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   }
 
   spec.add_runtime_dependency "tty-screen", "0.8.1"
-  spec.add_runtime_dependency "unicode-display_width", "2.2.0"
+  spec.add_runtime_dependency "unicode-display_width", "~> 2.2"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 13.0"


### PR DESCRIPTION
Thanks for this gem :)

When trying to install latest version of `rubocop`, `tabulo` version got downgraded to `1.x` because of `unicode-display-width` fixed dependency version.

I've tried to relax those dependencies versions. Hope CI still passes!