### PR TITLE
Bump unicode-display_width dependency

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+require "ostruct"
 require "simplecov"
 require "simplecov-lcov"
 

--- a/tabulo.gemspec
+++ b/tabulo.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   }
 
   spec.add_runtime_dependency "tty-screen", "0.8.2"
-  spec.add_runtime_dependency "unicode-display_width", "~> 2.5"
+  spec.add_runtime_dependency "unicode-display_width", "~> 3.0"
 
   spec.add_development_dependency "bundler", "~> 2.5"
   spec.add_development_dependency "rake", "~> 13.2.1"


### PR DESCRIPTION
The changes seem fine: https://github.com/janlelis/unicode-display_width/blob/main/CHANGELOG.md#300

I tried a few tables with complex emoji, and they seemed to render with the right width.